### PR TITLE
Allow per-field overriding of default_operator

### DIFF
--- a/filteralchemy/filterset.py
+++ b/filteralchemy/filterset.py
@@ -77,10 +77,12 @@ class FilterSetMeta(type):
                 opts.converter.field_for(opts.model, prop.key)
             )
             operators = overrides.get('operators') or opts.operators
+            default_operator = (overrides.get('default_operator') or
+                                opts.default_operator)
             for operator in operators:
                 operator_name = (
                     operator.label
-                    if operator != opts.default_operator
+                    if operator != default_operator
                     else None
                 )
                 name = underscore_formatter(prop.key, operator_name)


### PR DESCRIPTION
Hi! I'm thinking in using this library to refactor an existing RESTful API. I need to be able to override the `default_operator` attribute of some fields but not of all of them, but I noted that is not possible yet (the `column_overrides` doesn't use this). I wrote a simple fix for this issue.

With this change I could do something like this:
```python
class AlbumFilterSet(FilterSet):
    class Meta:
        model = Album
        query = session.query(Album)
        operators = (Equal, Greater, Less)
        column_overrides = {
            'name': {'default_operator': Like}
        }
```